### PR TITLE
Fix webcal link on CodeCumbria homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
       
       <div class="main-content">
         <p class="paragraph-short">
-          <a href="webcal:///codecumbria.ics"
+          <a href="webcal://codecumbria.github.io/codecumbria.ics"
              title="Subscribe to or download .ics calendar file"><time datetime="2013-04-24 19:00">Wednesday April 24<sup>th</sup>, 7pm</time></a>
           (last Wednesday of every month)
         </p>


### PR DESCRIPTION
Looks like absolute links (/codecumbria.ical) don't work when coupled with the webcal protocol (webcal://)
